### PR TITLE
Add support for supplying initial state through constructor

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -3,6 +3,7 @@ import { record2State, state2Record } from './transform'
 const noop = () => {}
 export class History {
   constructor (options = {
+    initialState: undefined,
     rules: [],
     delay: 50,
     maxLength: 100,
@@ -13,7 +14,7 @@ export class History {
     this.delay = options.delay || 50
     this.maxLength = options.maxLength || 100
     this.useChunks = options.useChunks === undefined ? true : options.useChunks
-    this.onChange = options.onChange || noop
+    this.onChange = noop
 
     this.$index = -1
     this.$records = []
@@ -23,6 +24,14 @@ export class History {
       state: null, pickIndex: null, onResolves: [], timer: null
     }
     this.$debounceTime = null
+
+    if (options.initialState !== undefined) {
+      this.pushSync(options.initialState);
+    }
+
+    if (options.onChange) {
+      this.onChange = options.onChange
+    }
   }
 
   // : boolean

--- a/src/history.test.js
+++ b/src/history.test.js
@@ -25,6 +25,12 @@ test('can init history', () => {
   expect(history.get()).toEqual(state)
 })
 
+test('can supply initial history', () => {
+  const state = getState()
+  const history = new History({ initialState: state })
+  expect(history.get()).toEqual(state)
+})
+
 test('has correct undo/redo flag', () => {
   const history = new History()
   expect(history.hasUndo).toBeFalsy()
@@ -241,6 +247,13 @@ test('support change callback', () => {
     expect(onChange.mock.calls.length).toBe(5)
     expect(onChange.mock.calls[4][0]).toEqual(newState)
   })
+})
+
+test("change callback isn't fired for initial state", () => {
+  const onChange = jest.fn(() => {})
+  const state = getState()
+  const history = new History({ initialState: state, onChange })
+  expect(onChange.mock.calls.length).toBe(0)
 })
 
 test('can disable chunking', () => {


### PR DESCRIPTION
Currently there is an issue where the 'on change' observer would be
called when setting the initial state of the history. This may not
necessarily be ideal. Right now the only way to avoid this is to
manually reassign 'history.onChange' after constructing the History
object. This feels quite hacky, and isn't supported by documentation.

By passing the initial state of the data into the constructor, a
documented way of handling this situation is provided. Critically, it
avoids the need to be fully aware of the internals of the History class.