### PR TITLE
Improve typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
-interface IHistoryOptions {
+export interface IHistoryOptions<T = any> {
     /**
      * Optional rules array for optimizing data transforming.
      * By defining rules you can specify how to transform between states and internal "chunks".
      */
-    rules?: IRuleOptions[];
+    rules?: IRuleOptions<T>[];
 
     /**
      * Optional initial state.
      */
-    initialState?: any;
+    initialState?: T;
 
     /**
      * Debounce time for push in milliseconds, 50 by default.
@@ -28,20 +28,22 @@ interface IHistoryOptions {
     /**
      * Fired when pushing / pulling states with changed state passed in.
      */
-    onChange?: (state: any) => void;
+    onChange?: (state: T) => void;
 }
 
-interface IRuleOptions {
+export interface IRuleOptions<T = any> {
     /**
      * Defines whether a rule can be matched.
      * @param state the state that you pushed.
      */
-    match: (state: any) => boolean;
+    match: (state: T) => boolean;
 
     /**
      * Split state into shareable chunks.
      */
-    toRecord: (state: any) => {
+    toRecord: (
+      state: T,
+    ) => {
         chunks: any[];
         children?: any[];
     };
@@ -50,46 +52,43 @@ interface IRuleOptions {
      * Parse the chunks back into the state node
      * @param shareableChunks
      */
-    fromRecord: (shareableChunks: {
-        chunks: any[],
-        children: any[]
-    }) => any;
+    fromRecord: (shareableChunks: { chunks: any[]; children: any[] }) => T;
 }
 
-export class History {
+export class History<T = any> {
     /**
      * Valid record length of current instance
      */
-    length: number;
+    readonly length: number;
 
     /**
      * Whether current state has undo records before.
      */
-    hasUndo: boolean;
+    readonly hasUndo: boolean;
 
     /**
      * Whether current state has redo records after.
      */
-    hasRedo: boolean;
+    readonly hasRedo: boolean;
 
     /**
      * Main class for state management
      */
-    constructor(options?: IHistoryOptions);
+    constructor(options?: IHistoryOptions<T>);
 
     /**
      * Push state data into history, using pushSync under the hood.
      * @param state state data to push.
      * @param pickIndex if specified, only this index of state's child will be serialized.
      */
-    push(state: any, pickIndex?: number): Promise<History>;
+    push(state: T, pickIndex?: number): Promise<History>;
 
     /**
      * Push state data into history.
      * @param state state data to push.
      * @param pickIndex if specified, only this index of state's child will be serialized.
      */
-    pushSync(state: any, pickIndex?: number): History;
+    pushSync(state: T, pickIndex?: number): History;
 
     /**
      * Undo a record if possible, supports chaining.
@@ -104,7 +103,7 @@ export class History {
     /**
      * Pull out a history state from records.
      */
-    get(): any;
+    get(): T;
 
     /**
      * Clear internal data structure.


### PR DESCRIPTION
- Add generics support in a way that is fully backwards-compatible.
- Mark some properties as readonly because they're implemented as
  getters in the actual History class and therefore can't be written to.
- Export the history options and rule options interfaces so they can
  more easily be used in custom code.